### PR TITLE
Use default encoding for Address() creation with non-byte host argument

### DIFF
--- a/enet.pyx
+++ b/enet.pyx
@@ -259,7 +259,7 @@ cdef class Address:
     def __init__(self, host, port):
         if host is not None:
             # Convert the hostname to a byte string if needed
-            self.host = host
+            self.host = host if isinstance(host, bytes) else host.encode()
         else:
             self.host = None
         self.port = port


### PR DESCRIPTION
The documentation says that Addess() accepts a str, but if a string is given pyenet will throw `expected bytes, str found`.
So using default encoding should fix this.