### PR TITLE
Update Cython dependency to version 3

### DIFF
--- a/enet.pyx
+++ b/enet.pyx
@@ -317,7 +317,7 @@ cdef class Address:
         def __set__(self, value):
             self._enet_address.port = value
 
-cdef void __cdecl _packet_free_callback(ENetPacket* packet) with gil:
+cdef void __cdecl _packet_free_callback(ENetPacket* packet) noexcept with gil:
     cdef object func = <object>packet.userData
     func()
     # the packet is about to be destroyed, so decrease the refcount

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Cython>=0,<1
+Cython>=3,<4

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     version=package_version,
     cmdclass={'build_ext': build_ext},
     ext_modules=ext_modules,
-    setup_requires=['Cython>=0,<1'],
-    install_requires=['Cython>=0,<1'],
+    setup_requires=['Cython>=3,<4'],
+    install_requires=['Cython>=3,<4'],
 )


### PR DESCRIPTION
Python 3.13 has removed some internal functions that Cython 0.29 depends on. This PR updates Cython to version 3. Since `language_level=2` is still allowed, not much needed to be changes in the code. Just a single line.

If this PR is accepted, you'll also need to update [pyproject.toml](https://github.com/piqueserver/piqueserver/blob/master/pyproject.toml) to allow Python 3.13 to be used.

I was able to compile piqueserver like this and join the server with the OpenSpades client. Seems to work.